### PR TITLE
update: README only update when pushed to main

### DIFF
--- a/.github/workflows/update-readme-tree.yml
+++ b/.github/workflows/update-readme-tree.yml
@@ -3,7 +3,7 @@ permissions:
   contents: write
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
 
 jobs:
   update-readme-tree:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the repository automation workflow to run only when changes are pushed to the main branch instead of all branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->