### PR TITLE
fix: supabase error

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -539,7 +539,25 @@ app.post('/api/auth/signup', async (c) => {
   });
 
   if (signUpError || !signUpData.user) {
-    return c.json({ error: signUpError?.message ?? 'Supabase signup failed' }, 400);
+    const rawMessage = signUpError?.message ?? 'Supabase signup failed';
+    const normalizedMessage = rawMessage.toLowerCase();
+    if (normalizedMessage.includes('database error saving new user')) {
+      return c.json({
+        error: 'Database error saving new user. Check public.profiles trigger/policies/constraints.',
+      }, 400);
+    }
+    return c.json({ error: rawMessage }, 400);
+  }
+
+  // With Confirm Email disabled, Supabase typically returns an active session here.
+  if (signUpData.session) {
+    return c.json({
+      id: signUpData.user.id,
+      username,
+      access_token: signUpData.session.access_token,
+      refresh_token: signUpData.session.refresh_token,
+      expires_at: signUpData.session.expires_at,
+    });
   }
 
   const { data: signInData, error: signInError } = await anon.auth.signInWithPassword({
@@ -549,12 +567,11 @@ app.post('/api/auth/signup', async (c) => {
 
   if (signInError || !signInData.session) {
     return c.json({
+      error: signInError?.message ?? 'Signup succeeded but no active session was returned.',
       id: signUpData.user.id,
-      username,
-      access_token: null,
-      message: 'Account created, but please log in manually.'
-    });
+    }, 401);
   }
+
   return c.json({
     id: signUpData.user.id,
     username,

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -522,7 +522,6 @@ app.post('/api/auth/signup', async (c) => {
   const email = typeof body.email === 'string' ? body.email.trim() : '';
   const password = typeof body.password === 'string' ? body.password : '';
   const username = typeof body.username === 'string' ? body.username.trim() : '';
-  const metadataUsername = typeof body.username === 'string' ? body.username.trim() : '';
 
   if (!email || !password || !username) {
     return c.json({ error: 'email, password, and username are required' }, 400);
@@ -571,7 +570,7 @@ app.post('/api/auth/signup', async (c) => {
     const createdUserUsername =
       typeof signUpData.user.user_metadata?.['username'] === 'string'
         ? signUpData.user.user_metadata['username']
-        : metadataUsername;
+        : username;
     return c.json({
       id: signUpData.user.id,
       username: createdUserUsername,

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -522,6 +522,7 @@ app.post('/api/auth/signup', async (c) => {
   const email = typeof body.email === 'string' ? body.email.trim() : '';
   const password = typeof body.password === 'string' ? body.password : '';
   const username = typeof body.username === 'string' ? body.username.trim() : '';
+  const metadataUsername = typeof body.username === 'string' ? body.username.trim() : '';
 
   if (!email || !password || !username) {
     return c.json({ error: 'email, password, and username are required' }, 400);
@@ -551,9 +552,10 @@ app.post('/api/auth/signup', async (c) => {
 
   // With Confirm Email disabled, Supabase typically returns an active session here.
   if (signUpData.session) {
+    const resolvedUsername = await fetchProfileUsername(signUpData.session.access_token, signUpData.user.id);
     return c.json({
       id: signUpData.user.id,
-      username,
+      username: resolvedUsername,
       access_token: signUpData.session.access_token,
       refresh_token: signUpData.session.refresh_token,
       expires_at: signUpData.session.expires_at,
@@ -566,15 +568,22 @@ app.post('/api/auth/signup', async (c) => {
   });
 
   if (signInError || !signInData.session) {
+    const createdUserUsername =
+      typeof signUpData.user.user_metadata?.['username'] === 'string'
+        ? signUpData.user.user_metadata['username']
+        : metadataUsername;
     return c.json({
-      error: signInError?.message ?? 'Signup succeeded but no active session was returned.',
       id: signUpData.user.id,
-    }, 401);
+      username: createdUserUsername,
+      access_token: null,
+    });
   }
+
+  const resolvedUsername = await fetchProfileUsername(signInData.session.access_token, signUpData.user.id);
 
   return c.json({
     id: signUpData.user.id,
-    username,
+    username: resolvedUsername,
     access_token: signInData.session.access_token,
     refresh_token: signInData.session.refresh_token,
     expires_at: signInData.session.expires_at,

--- a/apps/desktop/src-tauri/migrations/postgres/20260326170000_v6_profiles_rls_and_signup_safe_trigger.sql
+++ b/apps/desktop/src-tauri/migrations/postgres/20260326170000_v6_profiles_rls_and_signup_safe_trigger.sql
@@ -44,14 +44,24 @@ BEGIN
     SET username = COALESCE(EXCLUDED.username, public.profiles.username);
   EXCEPTION
     WHEN unique_violation THEN
-      INSERT INTO public.profiles (id, username, registered_at)
-      VALUES (NEW.id, 'user_' || SUBSTRING(NEW.id::TEXT, 1, 8), NOW())
-      ON CONFLICT (id) DO NOTHING;
+      BEGIN
+        INSERT INTO public.profiles (id, username, registered_at)
+        VALUES (NEW.id, 'user_' || SUBSTRING(NEW.id::TEXT, 1, 8), NOW())
+        ON CONFLICT (id) DO NOTHING;
+      EXCEPTION
+        WHEN OTHERS THEN
+          NULL;
+      END;
     WHEN OTHERS THEN
       -- Failsafe: do not block auth signup if profile insert has an unexpected issue.
-      INSERT INTO public.profiles (id, username, registered_at)
-      VALUES (NEW.id, NULL, NOW())
-      ON CONFLICT (id) DO NOTHING;
+      BEGIN
+        INSERT INTO public.profiles (id, username, registered_at)
+        VALUES (NEW.id, NULL, NOW())
+        ON CONFLICT (id) DO NOTHING;
+      EXCEPTION
+        WHEN OTHERS THEN
+          NULL;
+      END;
   END;
 
   RETURN NEW;
@@ -65,18 +75,71 @@ FOR EACH ROW
 EXECUTE FUNCTION public.handle_new_user();
 
 -- Backfill any missing profile rows for existing auth users.
-INSERT INTO public.profiles (id, username, registered_at)
-SELECT
-  au.id,
-  COALESCE(
-    NULLIF(BTRIM(au.raw_user_meta_data->>'username'), ''),
-    NULLIF(BTRIM(SPLIT_PART(COALESCE(au.email, ''), '@', 1)), ''),
-    'user_' || SUBSTRING(au.id::TEXT, 1, 8)
-  ) AS username,
-  NOW()
-FROM auth.users au
-LEFT JOIN public.profiles p ON p.id = au.id
-WHERE p.id IS NULL;
+DO $$
+DECLARE
+  rec RECORD;
+  raw_username TEXT;
+  normalized_username TEXT;
+  fallback_username TEXT;
+BEGIN
+  FOR rec IN
+    SELECT au.id, au.email, au.raw_user_meta_data
+    FROM auth.users au
+    LEFT JOIN public.profiles p ON p.id = au.id
+    WHERE p.id IS NULL
+  LOOP
+    raw_username := rec.raw_user_meta_data->>'username';
+    normalized_username := NULLIF(BTRIM(raw_username), '');
+
+    IF normalized_username IS NOT NULL AND LOWER(normalized_username) = 'unknown' THEN
+      normalized_username := NULL;
+    END IF;
+
+    IF normalized_username IS NOT NULL AND POSITION('@' IN normalized_username) > 0 THEN
+      normalized_username := NULL;
+    END IF;
+
+    fallback_username := NULLIF(BTRIM(SPLIT_PART(COALESCE(rec.email, ''), '@', 1)), '');
+    IF fallback_username IS NOT NULL AND LOWER(fallback_username) = 'unknown' THEN
+      fallback_username := NULL;
+    END IF;
+
+    IF fallback_username IS NOT NULL AND POSITION('@' IN fallback_username) > 0 THEN
+      fallback_username := NULL;
+    END IF;
+
+    BEGIN
+      INSERT INTO public.profiles (id, username, registered_at)
+      VALUES (
+        rec.id,
+        COALESCE(normalized_username, fallback_username, 'user_' || SUBSTRING(rec.id::TEXT, 1, 8)),
+        NOW()
+      )
+      ON CONFLICT (id) DO UPDATE
+      SET username = COALESCE(EXCLUDED.username, public.profiles.username);
+    EXCEPTION
+      WHEN unique_violation THEN
+        BEGIN
+          INSERT INTO public.profiles (id, username, registered_at)
+          VALUES (rec.id, 'user_' || SUBSTRING(rec.id::TEXT, 1, 8), NOW())
+          ON CONFLICT (id) DO NOTHING;
+        EXCEPTION
+          WHEN OTHERS THEN
+            NULL;
+        END;
+      WHEN OTHERS THEN
+        BEGIN
+          INSERT INTO public.profiles (id, username, registered_at)
+          VALUES (rec.id, NULL, NOW())
+          ON CONFLICT (id) DO NOTHING;
+        EXCEPTION
+          WHEN OTHERS THEN
+            NULL;
+        END;
+    END;
+  END LOOP;
+END;
+$$;
 
 -- Profiles RLS policies for frontend reads/updates.
 ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;

--- a/apps/desktop/src-tauri/migrations/postgres/20260326170000_v6_profiles_rls_and_signup_safe_trigger.sql
+++ b/apps/desktop/src-tauri/migrations/postgres/20260326170000_v6_profiles_rls_and_signup_safe_trigger.sql
@@ -1,0 +1,101 @@
+-- v6: Make auth signup resilient and RLS-complete for profiles.
+-- Goals:
+-- 1) Never fail auth signup because of profile-trigger insert issues.
+-- 2) Ensure profile row exists immediately after signup.
+-- 3) Allow authenticated users to read/update their own profile via RLS.
+
+-- Normalize username extraction and keep trigger safe.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  raw_username TEXT;
+  normalized_username TEXT;
+  fallback_username TEXT;
+BEGIN
+  raw_username := NEW.raw_user_meta_data->>'username';
+  normalized_username := NULLIF(BTRIM(raw_username), '');
+
+  IF normalized_username IS NOT NULL AND LOWER(normalized_username) = 'unknown' THEN
+    normalized_username := NULL;
+  END IF;
+
+  IF normalized_username IS NOT NULL AND POSITION('@' IN normalized_username) > 0 THEN
+    normalized_username := NULL;
+  END IF;
+
+  fallback_username := NULLIF(BTRIM(SPLIT_PART(COALESCE(NEW.email, ''), '@', 1)), '');
+  IF fallback_username IS NOT NULL AND LOWER(fallback_username) = 'unknown' THEN
+    fallback_username := NULL;
+  END IF;
+
+  -- Insert profile row immediately; avoid aborting auth.users transaction on collisions.
+  BEGIN
+    INSERT INTO public.profiles (id, username, registered_at)
+    VALUES (
+      NEW.id,
+      COALESCE(normalized_username, fallback_username, 'user_' || SUBSTRING(NEW.id::TEXT, 1, 8)),
+      NOW()
+    )
+    ON CONFLICT (id) DO UPDATE
+    SET username = COALESCE(EXCLUDED.username, public.profiles.username);
+  EXCEPTION
+    WHEN unique_violation THEN
+      INSERT INTO public.profiles (id, username, registered_at)
+      VALUES (NEW.id, 'user_' || SUBSTRING(NEW.id::TEXT, 1, 8), NOW())
+      ON CONFLICT (id) DO NOTHING;
+    WHEN OTHERS THEN
+      -- Failsafe: do not block auth signup if profile insert has an unexpected issue.
+      INSERT INTO public.profiles (id, username, registered_at)
+      VALUES (NEW.id, NULL, NOW())
+      ON CONFLICT (id) DO NOTHING;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_user();
+
+-- Backfill any missing profile rows for existing auth users.
+INSERT INTO public.profiles (id, username, registered_at)
+SELECT
+  au.id,
+  COALESCE(
+    NULLIF(BTRIM(au.raw_user_meta_data->>'username'), ''),
+    NULLIF(BTRIM(SPLIT_PART(COALESCE(au.email, ''), '@', 1)), ''),
+    'user_' || SUBSTRING(au.id::TEXT, 1, 8)
+  ) AS username,
+  NOW()
+FROM auth.users au
+LEFT JOIN public.profiles p ON p.id = au.id
+WHERE p.id IS NULL;
+
+-- Profiles RLS policies for frontend reads/updates.
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "profiles_select_own" ON public.profiles;
+CREATE POLICY "profiles_select_own"
+ON public.profiles
+FOR SELECT
+USING (auth.uid() = id);
+
+DROP POLICY IF EXISTS "profiles_update_own" ON public.profiles;
+CREATE POLICY "profiles_update_own"
+ON public.profiles
+FOR UPDATE
+USING (auth.uid() = id)
+WITH CHECK (auth.uid() = id);
+
+DROP POLICY IF EXISTS "profiles_insert_own" ON public.profiles;
+CREATE POLICY "profiles_insert_own"
+ON public.profiles
+FOR INSERT
+WITH CHECK (auth.uid() = id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signup error messaging for profile-creation failures.
  * Successful account creation now returns an authenticated session (tokens and expiry) immediately; username is resolved from the stored profile.
  * Sign-in failure responses consistently include user id and resolved username only.

* **Security**
  * Enforced row-level security on profiles so users can only read or modify their own profile.
  * Added guarded signup/backfill logic to avoid aborting account creation on profile write errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->